### PR TITLE
Fix: Add missing `graphql` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,21 @@
 {
   "name": "mcp-graphql-introspection",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "mcp-graphql-introspection",
+      "version": "1.0.4",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.0",
+        "graphql": "^16.11.0",
         "graphql-request": "^7.2.0",
         "zod": "^3.25.74"
+      },
+      "bin": {
+        "mcp-graphql-introspection": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^24.0.10",
@@ -497,7 +505,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.0",
+    "graphql": "^16.11.0",
     "graphql-request": "^7.2.0",
     "zod": "^3.25.74"
   },


### PR DESCRIPTION
When running the MCP client with version `1.0.4` of the `mcp-graphql-introspection` package, I encountered the following error:

```bash
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'graphql' imported from /user/.npm/_npx/5985/lib/node_modules/mcp-graphql-introspection/node_modules/graphql-request/build/legacy/helpers/analyzeDocument.js
    at packageResolve (node:internal/modules/esm/resolve:857:9)
    at moduleResolve (node:internal/modules/esm/resolve:926:18)
    at defaultResolve (node:internal/modules/esm/resolve:1056:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:654:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:603:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:586:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:242:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}
Node.js v22.13.0
Connection state: Error Process exited with code 1
```

This PR adds the missing `graphql` dependency